### PR TITLE
OGRIP LBRS

### DIFF
--- a/sources/us/oh/adams.json
+++ b/sources/us/oh/adams.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39001",
+            "name": "Adams County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Adams"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/ADA_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/allen.json
+++ b/sources/us/oh/allen.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39003",
+            "name": "Allen County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Allen"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/ALL_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/ashland.json
+++ b/sources/us/oh/ashland.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39005",
+            "name": "Ashland County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Ashland"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/ASH_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/ashtabula.json
+++ b/sources/us/oh/ashtabula.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39007",
+            "name": "Ashtabula County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Ashtabula"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/ATB_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/athens.json
+++ b/sources/us/oh/athens.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39009",
+            "name": "Athens County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Athens"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/ATH_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/auglaize.json
+++ b/sources/us/oh/auglaize.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39011",
+            "name": "Auglaize County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Auglaize"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/AUG_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/brown.json
+++ b/sources/us/oh/brown.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39015",
+            "name": "Brown County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Brown"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/BRO_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/butler.json
+++ b/sources/us/oh/butler.json
@@ -1,0 +1,52 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39017",
+            "name": "Butler County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Butler"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/BUT_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    },
+      "unit": "UNITNUM",
+      "type": "shapefile",
+      "postcode": "zipcode"
+    }
+}

--- a/sources/us/oh/carroll.json
+++ b/sources/us/oh/carroll.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39019",
+            "name": "Carroll County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Carroll"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/CAR_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2010,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/champaign.json
+++ b/sources/us/oh/champaign.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39021",
+            "name": "Champaign County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Champaign"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/CHP_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/clark.json
+++ b/sources/us/oh/clark.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39023",
+            "name": "Clark County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Clark"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/CLA_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2012,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/clermont.json
+++ b/sources/us/oh/clermont.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39025",
+            "name": "Clermont County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Clermont"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/CLE_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/clinton.json
+++ b/sources/us/oh/clinton.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39027",
+            "name": "Clinton County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Clinton"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/CLI_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/columbiana.json
+++ b/sources/us/oh/columbiana.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39029",
+            "name": "Columbiana County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Columbiana"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/COL_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/coshocton.json
+++ b/sources/us/oh/coshocton.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39031",
+            "name": "Coshocton County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Coshocton"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/COS_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/crawford.json
+++ b/sources/us/oh/crawford.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39033",
+            "name": "Crawford County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Crawford"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/CRA_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/cuyahoga.json
+++ b/sources/us/oh/cuyahoga.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39035",
+            "name": "Cuyahoga County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Cuyahoga"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/CUY_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/darke.json
+++ b/sources/us/oh/darke.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39037",
+            "name": "Darke County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Darke"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/DAR_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/defiance.json
+++ b/sources/us/oh/defiance.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39039",
+            "name": "Defiance County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Defiance"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/DEF_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/delaware.json
+++ b/sources/us/oh/delaware.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39041",
+            "name": "Delaware County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Delaware"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/DEL_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/erie.json
+++ b/sources/us/oh/erie.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39043",
+            "name": "Erie County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Erie"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/ERI_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/fairfield.json
+++ b/sources/us/oh/fairfield.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39045",
+            "name": "Fairfield County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Fairfield"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/FAI_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/fayette.json
+++ b/sources/us/oh/fayette.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39047",
+            "name": "Fayette County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Fayette"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/FAY_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/franklin.json
+++ b/sources/us/oh/franklin.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39049",
+            "name": "Franklin County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Franklin"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/FRA_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/fulton.json
+++ b/sources/us/oh/fulton.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39051",
+            "name": "Fulton County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Fulton"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/FUL_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2015,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/gallia.json
+++ b/sources/us/oh/gallia.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39053",
+            "name": "Gallia County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Gallia"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/GAL_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2013,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/greene.json
+++ b/sources/us/oh/greene.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39057",
+            "name": "Greene County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Greene"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/GRE_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2014,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/guernsey.json
+++ b/sources/us/oh/guernsey.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39059",
+            "name": "Guernsey County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Guernsey"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/GUE_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/hancock.json
+++ b/sources/us/oh/hancock.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39063",
+            "name": "Hancock County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Hancock"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/HAN_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/hardin.json
+++ b/sources/us/oh/hardin.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39065",
+            "name": "Hardin County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Hardin"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/HAR_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/harrison.json
+++ b/sources/us/oh/harrison.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39067",
+            "name": "Harrison County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Harrison"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/HAS_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2009,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/henry.json
+++ b/sources/us/oh/henry.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39069",
+            "name": "Henry County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Henry"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/HEN_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2009,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/highland.json
+++ b/sources/us/oh/highland.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39071",
+            "name": "Highland County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Highland"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/HIG_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2015,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/hocking.json
+++ b/sources/us/oh/hocking.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39073",
+            "name": "Hocking County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Hocking"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/HOC_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/holmes.json
+++ b/sources/us/oh/holmes.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39075",
+            "name": "Holmes County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Holmes"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/HOL_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/huron.json
+++ b/sources/us/oh/huron.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39077",
+            "name": "Huron County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Huron"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/HUR_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2015,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/jackson.json
+++ b/sources/us/oh/jackson.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39079",
+            "name": "Jackson County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Jackson"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/JAC_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/jefferson.json
+++ b/sources/us/oh/jefferson.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39081",
+            "name": "Jefferson County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Jefferson"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/JEF_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2010,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/knox.json
+++ b/sources/us/oh/knox.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39083",
+            "name": "Knox County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Knox"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/KNO_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/lake.json
+++ b/sources/us/oh/lake.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39085",
+            "name": "Lake County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Lake"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/LAK_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2013,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/lawrence.json
+++ b/sources/us/oh/lawrence.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39087",
+            "name": "Lawrence County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Lawrence"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/LAW_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2012,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/licking.json
+++ b/sources/us/oh/licking.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39089",
+            "name": "Licking County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Licking"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/LIC_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/logan.json
+++ b/sources/us/oh/logan.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39091",
+            "name": "Logan County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Logan"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/LOG_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/lorain.json
+++ b/sources/us/oh/lorain.json
@@ -1,0 +1,44 @@
+{
+    "coverage": {
+        "US Census": {"geoid": "39093", "name": "Lorain County", "state": "Ohio"},
+        "country": "us",
+        "state": "oh",
+        "county": "Lorain"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/LUC_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/lucas.json
+++ b/sources/us/oh/lucas.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39095",
+            "name": "Lucas County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Lucas"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/LUC_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/madison.json
+++ b/sources/us/oh/madison.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39097",
+            "name": "Madison County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Madison"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MAD_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2015,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/mahoning.json
+++ b/sources/us/oh/mahoning.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39099",
+            "name": "Mahoning County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Mahoning"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MAH_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2010,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/marion.json
+++ b/sources/us/oh/marion.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39101",
+            "name": "Marion County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Marion"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MAR_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/meigs.json
+++ b/sources/us/oh/meigs.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39105",
+            "name": "Meigs County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Meigs"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MEI_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2014,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/mercer.json
+++ b/sources/us/oh/mercer.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39107",
+            "name": "Mercer County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Mercer"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MER_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/miami.json
+++ b/sources/us/oh/miami.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39109",
+            "name": "Miami County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Miami"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MIA_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/monroe.json
+++ b/sources/us/oh/monroe.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39111",
+            "name": "Monroe County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Monroe"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MOE_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2009,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/montgomery.json
+++ b/sources/us/oh/montgomery.json
@@ -1,0 +1,44 @@
+{
+    "coverage": {
+        "US Census": {"geoid": "39113", "name": "Montgomery County", "state": "Ohio"},
+        "country": "us",
+        "state": "oh",
+        "county": "Montgomery"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MOT_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/morgan.json
+++ b/sources/us/oh/morgan.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39115",
+            "name": "Morgan County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Morgan"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MRG_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/morrow.json
+++ b/sources/us/oh/morrow.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39117",
+            "name": "Morrow County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Morrow"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MRW_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/muskingum.json
+++ b/sources/us/oh/muskingum.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39119",
+            "name": "Muskingum County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Muskingum"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/MUS_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2018,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/noble.json
+++ b/sources/us/oh/noble.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39121",
+            "name": "Noble County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Noble"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/NOB_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/ottawa.json
+++ b/sources/us/oh/ottawa.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39123",
+            "name": "Ottawa County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Ottawa"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/OTT_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/paulding.json
+++ b/sources/us/oh/paulding.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39125",
+            "name": "Paulding County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Paulding"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/PAU_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/perry.json
+++ b/sources/us/oh/perry.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39127",
+            "name": "Perry County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Perry"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/PER_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2012,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/pickaway.json
+++ b/sources/us/oh/pickaway.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39129",
+            "name": "Pickaway County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Pickaway"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/PIC_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/pike.json
+++ b/sources/us/oh/pike.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39131",
+            "name": "Pike County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Pike"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/PIK_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2009,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/portage.json
+++ b/sources/us/oh/portage.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39133",
+            "name": "Portage County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Portage"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/POR_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/preble.json
+++ b/sources/us/oh/preble.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39135",
+            "name": "Preble County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Preble"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/PRE_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/putnam.json
+++ b/sources/us/oh/putnam.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39137",
+            "name": "Putnam County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Putnam"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/PUT_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/richland.json
+++ b/sources/us/oh/richland.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39139",
+            "name": "Richland County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Richland"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/RIC_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/ross.json
+++ b/sources/us/oh/ross.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39141",
+            "name": "Ross County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Ross"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/ROS_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/sandusky.json
+++ b/sources/us/oh/sandusky.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39143",
+            "name": "Sandusky County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Sandusky"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/SAN_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2014,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/scioto.json
+++ b/sources/us/oh/scioto.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39145",
+            "name": "Scioto County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Scioto"
+    },
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/trescube/283809/us-oh-scioto.geojson.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/seneca.json
+++ b/sources/us/oh/seneca.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39147",
+            "name": "Seneca County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Seneca"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/SEN_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/shelby.json
+++ b/sources/us/oh/shelby.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39149",
+            "name": "Shelby County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Shelby"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/SHE_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/stark.json
+++ b/sources/us/oh/stark.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39151",
+            "name": "Stark County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Stark"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/STA_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/summit.json
+++ b/sources/us/oh/summit.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39153",
+            "state": "Ohio",
+            "name": "Summit County"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "summit"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/SUM_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/trumbull.json
+++ b/sources/us/oh/trumbull.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39155",
+            "name": "Trumbull County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Trumbull"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/TRU_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/tuscarawas.json
+++ b/sources/us/oh/tuscarawas.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39157",
+            "name": "Tuscarawas County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Tuscarawas"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/TUS_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2014,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/van_wert.json
+++ b/sources/us/oh/van_wert.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39161",
+            "name": "Van Wert County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Van Wert"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/VAN_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2016,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/vinton.json
+++ b/sources/us/oh/vinton.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39163",
+            "name": "Vinton County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Vinton"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/VIN_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/washington.json
+++ b/sources/us/oh/washington.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39167",
+            "name": "Washington County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Washington"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/WAS_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/wayne.json
+++ b/sources/us/oh/wayne.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39169",
+            "name": "Wayne County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Wayne"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/WAY_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/williams.json
+++ b/sources/us/oh/williams.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39171",
+            "name": "Williams County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Williams"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/WIL_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/wood.json
+++ b/sources/us/oh/wood.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39173",
+            "name": "Wood County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Wood"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/WOO_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}

--- a/sources/us/oh/wyandot.json
+++ b/sources/us/oh/wyandot.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "39175",
+            "name": "Wyandot County",
+            "state": "Ohio"
+        },
+        "country": "us",
+        "state": "oh",
+        "county": "Wyandot"
+    },
+    "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/WYA_CL.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "url": "http://gis3.oit.ohio.gov/LBRS/_downloads/docs/White%20Paper-LBRS_2011.pdf#page=4"
+    },
+    "year": 2017,
+    "conform": {
+        "type": "shp",
+        "addr:from:left": "L_ADD_FROM",
+        "addr:from:right": "R_ADD_FROM",
+        "addr:to:left": "L_ADD_TO",
+        "addr:to:right": "R_ADD_TO",
+        "city:left": "L_CITY",
+        "city:right": "R_CITY",
+        "dual_carriageway": "DIV",
+        "lanes": "LANES",
+        "maxspeed": {
+            "function": "format",
+            "fields": ["SPEED"],
+            "format": "$1 mph"
+        },
+        "name": [
+            "ST_PRE",
+            "ST_NAME",
+            "ST_TYPE",
+            "ST_SUFFIX"
+        ],
+        "oneway": "DIR_TRAV",
+        "postcode:left": "L_ZIP",
+        "postcode:right": "R_ZIP",
+        "ref": "RD_NUM",
+        "surface": "STYPE",
+        "township:left": "L_TWP",
+        "township:right": "R_TWP"
+    }
+}


### PR DESCRIPTION
Added the OGRIP LBRS datasets, which cover 82 of 88 Ohio counties. [This document](http://gis3.oit.ohio.gov/LBRS/_downloads/docs/LBRS%20Specifications%203%20FINAL.pdf#page=9) details the fields in each shapefile.

Fixes #24.